### PR TITLE
refactor: 환자 리포지토리 및 엑셀 파서 서비스 개선

### DIFF
--- a/src/domain/patient/patient.respository.ts
+++ b/src/domain/patient/patient.respository.ts
@@ -67,7 +67,8 @@ export class PatientRepository
                   t.address,
                   t.memo
                 FROM temp_patients t
-                WHERE NOT EXISTS (
+                WHERE t.chart_number IS NULL
+                AND NOT EXISTS (
                   SELECT 1 
                   FROM patients p
                   WHERE p.name = t.name

--- a/src/modules/patient/service/excel-parser.service.ts
+++ b/src/modules/patient/service/excel-parser.service.ts
@@ -126,13 +126,6 @@ export class ExcelParserService {
             return upper.isChartNumberEqual(lower);
         }
 
-        // 위에만 chartNumber가 있고 아래는 없어도 → 병합 OK
-        if (upperHasChartNumber && !lowerHasChartNumber) return true;
-
-        // 둘 다 없음 → 병합 OK
-        if (!upperHasChartNumber && !lowerHasChartNumber) return true;
-
-        // 아래만 chartNumber가 있고 위는 없음 → 병합 x
-        return false;
+        return true;
     }
 }

--- a/src/modules/patient/vo/patient.vo.ts
+++ b/src/modules/patient/vo/patient.vo.ts
@@ -20,12 +20,12 @@ export class PatientVO {
 
     mergeWith(other: PatientVO): PatientVO {
         return new PatientVO(
-            this.name,
-            this.phoneNumber,
-            this.rrn || other.rrn,
-            this.chartNumber || other.chartNumber,
-            this.address || other.address,
-            this.memo || other.memo,
+            other.name || this.name,
+            other.phoneNumber || this.phoneNumber,
+            other.rrn || this.rrn,
+            other.chartNumber || this.chartNumber,
+            other.address || this.address,
+            other.memo || this.memo,
         );
     }
 


### PR DESCRIPTION
- 환자 리포지토리에서 SQL 쿼리를 수정하여 차트 번호가 NULL인 경우에만 데이터를 선택하도록 변경함.
- 엑셀 파서 서비스에서 병합 로직을 단순화하여 항상 true를 반환하도록 수정함.
- PatientVO의 mergeWith 메서드에서 속성 병합 순서를 변경하여 우선순위를 조정함.